### PR TITLE
Add assert_permit with actions as array

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,11 @@ class ArticlePolicyTest < PolicyAssertions::Test
     assert_permit @user, Article, 'index?', 'show?'
   end
 
+  # Actions can also be passed as an array
+  test 'index?' do
+    assert_permit @user, Article, %w(index? show?)
+  end
+
   # this will result in a
   # PolicyAssertions::MissingBlockParameters error
   test 'show?' do

--- a/lib/policy_assertions.rb
+++ b/lib/policy_assertions.rb
@@ -16,7 +16,7 @@ require 'policy_assertions/configuration'
 module PolicyAssertions
   class Test < ActiveSupport::TestCase
     def assert_permit(user, record, *permissions)
-      get_permissions(permissions).each do |permission|
+      get_permissions(permissions.flatten).each do |permission|
         policy = Pundit.policy!(user, record)
         assert policy.public_send(permission),
                "Expected #{policy.class.name} to grant #{permission} "\
@@ -25,7 +25,7 @@ module PolicyAssertions
     end
 
     def refute_permit(user, record, *permissions)
-      get_permissions(permissions).each do |permission|
+      get_permissions(permissions.flatten).each do |permission|
         policy = Pundit.policy!(user, record)
         refute policy.public_send(permission),
                "Expected #{policy.class.name} not to grant #{permission} "\

--- a/test/lib/policy_assertions_test.rb
+++ b/test/lib/policy_assertions_test.rb
@@ -197,8 +197,16 @@ class ValidBlockParametersTest
       assert_permit nil, Article, 'index?', 'long_action?'
     end
 
+    test 'assert_permit index? as array' do
+      assert_permit nil, Article, %w(index? long_action?)
+    end
+
     test 'destroy?' do
       refute_permit nil, Article, 'destroy?'
+    end
+
+    test 'refute_permit destroy? as array' do
+      refute_permit nil, Article, %w(destroy?)
     end
   end
 end


### PR DESCRIPTION
Adds the ability to use `assert_permit @user, Class, %w(index? new? create? ...)`