### PR TITLE
Add assert not permitted

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ class ArticlePolicyTest < PolicyAssertions::Test
   # Test that this user cannot delete this article
   def test_destroy
     refute_permit users(:regular), articles(:instructions)
+    # Alternate method name
+    asssert_not_permitted users(:regular), articles(:instructions)
   end
 
   # Test a permission by passing in an array instead of

--- a/lib/policy_assertions.rb
+++ b/lib/policy_assertions.rb
@@ -32,6 +32,7 @@ module PolicyAssertions
                "on #{record} for #{user} but it did"
       end
     end
+    alias assert_not_permitted refute_permit
 
     def assert_strong_parameters(user, record, params_hash, allowed_params)
       policy = Pundit.policy!(user, record)

--- a/test/lib/policy_assertions_test.rb
+++ b/test/lib/policy_assertions_test.rb
@@ -102,6 +102,17 @@ class AssertionsTest < Minitest::Test
     assert test_runner.passed?
   end
 
+  def test_permission_failed_as_assert_not_permitted
+    test_runner = policy_class do
+      def test_create
+        assert_not_permitted nil, Article
+      end
+    end.new :test_create
+
+    test_runner.run
+    assert test_runner.passed?
+  end
+
   def test_destroy
     test_runner = policy_class do
       def test_destroy
@@ -199,6 +210,10 @@ class ValidBlockParametersTest
 
     test 'destroy?' do
       refute_permit nil, Article, 'destroy?'
+    end
+
+    test 'destroy? with assert_not_permitted' do
+      assert_not_permitted nil, Article, 'destroy?'
     end
   end
 end


### PR DESCRIPTION
Since minitest uses `assert` and `assert_not`, I propose we add an `assert_not_permitted`. While longer, it follows minitest (and the ProctorU styleguide).