### PR TITLE
Add support for testing policies that are not of type "#{record.class}Policy"

### DIFF
--- a/lib/policy_assertions.rb
+++ b/lib/policy_assertions.rb
@@ -17,7 +17,7 @@ module PolicyAssertions
   class Test < ActiveSupport::TestCase
     def assert_permit(user, record, *permissions)
       get_permissions(permissions.flatten).each do |permission|
-        policy = Pundit.policy!(user, record)
+        policy = find_policy!(user, record)
         assert policy.public_send(permission),
                "Expected #{policy.class.name} to grant #{permission} "\
                "on #{record} for #{user} but it didn't"
@@ -26,7 +26,7 @@ module PolicyAssertions
 
     def refute_permit(user, record, *permissions)
       get_permissions(permissions.flatten).each do |permission|
-        policy = Pundit.policy!(user, record)
+        policy = find_policy!(user, record)
         refute policy.public_send(permission),
                "Expected #{policy.class.name} not to grant #{permission} "\
                "on #{record} for #{user} but it did"
@@ -35,7 +35,7 @@ module PolicyAssertions
     alias assert_not_permitted refute_permit
 
     def assert_strong_parameters(user, record, params_hash, allowed_params)
-      policy = Pundit.policy!(user, record)
+      policy = find_policy!(user, record)
 
       param_key = find_param_key(record)
 
@@ -82,6 +82,11 @@ module PolicyAssertions
       else
         caller[2][/`.*'/][1..-2]
       end
+    end
+
+    def find_policy!(user, record)
+      described_policy = self.respond_to?(:described_class) ? described_class : nil
+      described_policy ? described_policy.new(user, record) : Pundit.policy!(user, record)
     end
   end
 end

--- a/test/lib/policy_assertions_test.rb
+++ b/test/lib/policy_assertions_test.rb
@@ -123,6 +123,21 @@ class AssertionsTest < Minitest::Test
     test_runner.run
     assert test_runner.passed?
   end
+
+  def test_described_class
+    test_runner = custom_policy_class do
+      def described_class
+        CustomPolicy
+      end
+
+      def test_new
+        assert_permit User.new(100), Article.new(100)
+      end
+    end.new :test_new
+
+    test_runner.run
+    assert test_runner.passed?
+  end
 end
 
 class StrongParametersTest < Minitest::Test

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,6 +15,15 @@ def policy_class(&block)
   klass
 end
 
+def custom_policy_class(&block)
+  klass = Class.new(PolicyAssertions::Test, &block)
+  def klass.name
+    'CustomPolicyTest'
+  end
+
+  klass
+end
+
 class User
   def self.policy_class
     PersonPolicy
@@ -90,6 +99,19 @@ class PersonPolicy
 
   def permitted_attributes
     (@user && @user.id == 1) ? [:user_id, :name, :role] : [:user_id, :name]
+  end
+end
+
+class CustomPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def new?
+    record.is_a?(Article)
   end
 end
 


### PR DESCRIPTION
There are cases where a Policy class name is manually defined (not inferred from the model name).

Example:

```ruby
# app/policies/my_custom_article_policy.rb
class MyCustomArticlePolicy < ApplicationPolicy
  def new?
    false
  end
end

# in a controller
authorize @article, policy_class: MyCustomArticlePolicy
```
That means that a `MyCustomArticlePolicy` exists in the application code. However, when using `policy-assertions` this is not supported (since it will try to instantiate `ArticlePolicy`:

```ruby
class MyCustomArticlePolicyTest < PolicyAssertions::Test
  it 'new? denies access' do
    refute_permit @user, @article, 'new?'
  end
end
```

This is a proposal (inspired by https://github.com/varvet/pundit#policy-specs):

```ruby
class MyCustomArticlePolicyTest < PolicyAssertions::Test
  def described_class
    MyCustomArticlePolicy
  end

  it 'new? denies access' do
    refute_permit @user, @article, 'new?'
  end
end
```

Let me know what you think.
Thanks!